### PR TITLE
Fix build with gcc-13

### DIFF
--- a/metro/include/metro/ShotgunStochasticSearch.hpp
+++ b/metro/include/metro/ShotgunStochasticSearch.hpp
@@ -7,6 +7,7 @@
 #ifndef METRO_SHOTGUNSTOCHASTICSEARCH_HPP
 #define METRO_SHOTGUNSTOCHASTICSEARCH_HPP
 
+#include <cstdint>
 #include <vector>
 #include <unordered_map>
 #include <boost/function.hpp>


### PR DESCRIPTION
 The new compiler version requires explicitly including the header `cstdint` for types such as `std::uint32_t`, etc.
 See also https://gcc.gnu.org/gcc-13/porting_to.html